### PR TITLE
fix namespace in memfun.hpp

### DIFF
--- a/memfun.hpp
+++ b/memfun.hpp
@@ -12,102 +12,38 @@ namespace gnr
 namespace
 {
 
-template <typename FP, FP fp, typename R, class C, typename ...A>
-inline auto member_delegate(C* const object,
-  R (C::* const)(A...) const) noexcept
-{
-  return [object](A&& ...args) noexcept(
-      noexcept((object->*fp)(::std::forward<A>(args)...))
-    )
-    {
-      return (object->*fp)(::std::forward<A>(args)...);
-    };
+#define GNR_GEN_MEM_DELEGATE(OBJECT, MEMFUN, CAPTURE, CALL)	   \
+template <typename FP, FP fp, typename R, class C, typename ...A>  \
+inline auto member_delegate(OBJECT, MEMFUN) noexcept               \
+{                                                                  \
+  return [CAPTURE](A&& ...args) noexcept(                          \
+      noexcept((CALL)(::std::forward<A>(args)...))                 \
+    )                                                              \
+    {                                                              \
+      return (CALL)(::std::forward<A>(args)...);                   \
+    };                                                             \
 }
 
-template <typename FP, FP fp, typename R, class C, typename ...A>
-inline auto member_delegate(C* const object,
-  R (C::* const)(A...) const volatile) noexcept
-{
-  return [object](A&& ...args) noexcept(
-      noexcept((object->*fp)(::std::forward<A>(args)...))
-    )
-    {
-      return (object->*fp)(::std::forward<A>(args)...);
-    };
-}
+GNR_GEN_MEM_DELEGATE(C* const       object, R (C::* const)(A...) const,           object, object->*fp)
+GNR_GEN_MEM_DELEGATE(C* const       object, R (C::* const)(A...) const volatile,  object, object->*fp)
+GNR_GEN_MEM_DELEGATE(C* const       object, R (C::* const)(A...)       volatile,  object, object->*fp)
+GNR_GEN_MEM_DELEGATE(C* const       object, R (C::* const)(A...),                 object, object->*fp)
 
-template <typename FP, FP fp, typename R, class C, typename ...A>
-inline auto member_delegate(C* const object,
-  R (C::* const)(A...) volatile) noexcept
-{
-  return [object](A&& ...args) noexcept(
-      noexcept((object->*fp)(::std::forward<A>(args)...))
-    )
-    {
-      return (object->*fp)(::std::forward<A>(args)...);
-    };
-}
+GNR_GEN_MEM_DELEGATE(const C* const object, R (C::* const)(A...) const,           object, object->*fp)
+GNR_GEN_MEM_DELEGATE(const C* const object, R (C::* const)(A...) const volatile,  object, object->*fp)
+GNR_GEN_MEM_DELEGATE(const C* const object, R (C::* const)(A...)       volatile,  object, object->*fp)
+GNR_GEN_MEM_DELEGATE(const C* const object, R (C::* const)(A...),                 object, object->*fp)
 
-template <typename FP, FP fp, typename R, class C, typename ...A>
-inline auto member_delegate(C* const object,
-  R (C::* const)(A...)) noexcept
-{
-  return [object](A&& ...args) noexcept(
-      noexcept((object->*fp)(::std::forward<A>(args)...))
-    )
-    {
-      return (object->*fp)(::std::forward<A>(args)...);
-    };
-}
+GNR_GEN_MEM_DELEGATE(C&             object, R (C::* const)(A...) const,          &object, object.*fp)
+GNR_GEN_MEM_DELEGATE(C&             object, R (C::* const)(A...) const volatile, &object, object.*fp)
+GNR_GEN_MEM_DELEGATE(C&             object, R (C::* const)(A...)       volatile, &object, object.*fp)
+GNR_GEN_MEM_DELEGATE(C&             object, R (C::* const)(A...),                &object, object.*fp)
 
-template <typename FP, FP fp, typename R, class C, typename ...A>
-inline auto member_delegate(C& object,
-  R (C::* const)(A...) const) noexcept
-{
-  return [&object](A&& ...args) noexcept(
-      noexcept((object.*fp)(::std::forward<A>(args)...))
-    )
-    {
-      return (object.*fp)(::std::forward<A>(args)...);
-    };
-}
-
-template <typename FP, FP fp, typename R, class C, typename ...A>
-inline auto member_delegate(C& object,
-  R (C::* const)(A...) const volatile) noexcept
-{
-  return [&object](A&& ...args) noexcept(
-      noexcept((object.*fp)(::std::forward<A>(args)...))
-    )
-    {
-      return (object.*fp)(::std::forward<A>(args)...);
-    };
-}
-
-template <typename FP, FP fp, typename R, class C, typename ...A>
-inline auto member_delegate(C& object,
-  R (C::* const)(A...) volatile) noexcept
-{
-  return [&object](A&& ...args) noexcept(
-      noexcept((object.*fp)(::std::forward<A>(args)...))
-    )
-    {
-      return (object.*fp)(::std::forward<A>(args)...);
-    };
-}
-
-template <typename FP, FP fp, typename R, class C, typename ...A>
-inline auto member_delegate(C& object,
-  R (C::* const)(A...)) noexcept
-{
-  return [&object](A&& ...args) noexcept(
-      noexcept((object.*fp)(::std::forward<A>(args)...))
-    )
-    {
-      return (object.*fp)(::std::forward<A>(args)...);
-    };
-}
-
+GNR_GEN_MEM_DELEGATE(const       C& object, R (C::* const)(A...) const,          &object, object.*fp)
+GNR_GEN_MEM_DELEGATE(const       C& object, R (C::* const)(A...) const volatile, &object, object.*fp)
+GNR_GEN_MEM_DELEGATE(const       C& object, R (C::* const)(A...)       volatile, &object, object.*fp)
+GNR_GEN_MEM_DELEGATE(const       C& object, R (C::* const)(A...),                &object, object.*fp)
+    
 }
 
 template <typename FP, FP fp, class C>
@@ -117,7 +53,19 @@ inline auto mem_fun(C* const object) noexcept
 }
 
 template <typename FP, FP fp, class C>
+inline auto mem_fun(const C* const object) noexcept
+{
+  return member_delegate<FP, fp>(object, fp);
+}
+
+template <typename FP, FP fp, class C>
 inline auto mem_fun(C& object) noexcept
+{
+  return member_delegate<FP, fp>(object, fp);
+}
+
+template <typename FP, FP fp, class C>
+inline auto mem_fun(const C& object) noexcept
 {
   return member_delegate<FP, fp>(object, fp);
 }

--- a/memfun.hpp
+++ b/memfun.hpp
@@ -113,13 +113,13 @@ inline auto member_delegate(C& object,
 template <typename FP, FP fp, class C>
 inline auto mem_fun(C* const object) noexcept
 {
-  return detail::mem_fun::member_delegate<FP, fp>(object, fp);
+  return member_delegate<FP, fp>(object, fp);
 }
 
 template <typename FP, FP fp, class C>
 inline auto mem_fun(C& object) noexcept
 {
-  return detail::mem_fun::member_delegate<FP, fp>(object, fp);
+  return member_delegate<FP, fp>(object, fp);
 }
 
 }


### PR DESCRIPTION
Hi!

After having seen your code on codereview.stackexchange.com ([ref](https://codereview.stackexchange.com/q/14730)) I came across your generic repository.
Very nice code. (I think I can learn from your code!)

In this pull-request, there is a minor fix for memfun.hpp

How do you use your library, particularly with regard to delegates etc?
(I've worked out an example here: https://github.com/user706/code_generic/blob/master/code/code/main.cpp
Is this how you yourself would use your library, regarding mem_fun.hpp and forwarder.hpp?)

Thanks,
user706 ;)